### PR TITLE
Updates ezforms-bundle version listed in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Installation
 ```js
 {
     require: {
-        "heliopsis/ezforms-bundle": "1.0.*"
+        "heliopsis/ezforms-bundle": "1.1.*"
     }
 }
 ```


### PR DESCRIPTION
It looks like there is a newer version released and the readme hasn't been updated yet.
