### PR TITLE
Updates HandlerProvider example

### DIFF
--- a/Heliopsis/eZFormsBundle/Resources/doc/index.md
+++ b/Heliopsis/eZFormsBundle/Resources/doc/index.md
@@ -108,6 +108,7 @@ namespace Acme\FormsBundle\Providers;
 use Heliopsis\eZFormsBundle\Provider\HandlerProviderInterface;
 use Heliopsis\eZFormsBundle\FormHandler\FormHandlerInterface;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use Symfony\Component\Form\FormFactoryInterface;
 
 class HandlerProvider implements HandlerProviderInterface
 {


### PR DESCRIPTION
The HandlerProvider example was not using the Symfony FormFactoryInterface, so it was causing an error due to the constructor relying on it.
